### PR TITLE
Validate challenge right away

### DIFF
--- a/ACMECert.php
+++ b/ACMECert.php
@@ -198,11 +198,6 @@ class ACMECert extends ACMEv2 { // ACMECert - PHP client library for Let's Encry
 						$this->log('Triggering challenge callback for '.$domain.' using '.$type);
 						$remove_cb=$callback($opts);
 
-						$pending_challenges[]=array($remove_cb,$opts,$challenge_url,$auth_url);
-					}
-
-					foreach($pending_challenges as $arr){
-						list($remove_cb,$opts,$challenge_url,$auth_url)=$arr;
 						$this->log('Notifying server for validation of '.$opts['domain']);
 						$this->request($challenge_url,new StdClass);
 


### PR DESCRIPTION
Registering all the challenges at once and validating them all together is a problem when you have a CSR which contains *.example.com and example.com. The challenges for dns-01 are _acme-challenge.example.com for both cases (with different tokens) so it will always fail.

Doing this in one step will avoid the problem