### PR TITLE
Added authz_reuse parameter to getCertificateChain to toggle authorization reuse

### DIFF
--- a/ACMECert.php
+++ b/ACMECert.php
@@ -102,29 +102,11 @@ class ACMECert extends ACMEv2 { // ACMECert - PHP client library for Let's Encry
 		$this->log('Certificate revoked');
 	}
 
-	public function getCertificateChain($pem,$domain_config,$callback){
+	public function getCertificateChain($pem,$domain_config,$callback,$force_validation=false){
 		$domain_config=array_change_key_case($domain_config,CASE_LOWER);
 		$domains=array_keys($domain_config);
-
-		// autodetect if Private Key or CSR is used
-		if ($key=openssl_pkey_get_private($pem)){ // Private Key detected
-			openssl_free_key($key);
-			$this->log('Generating CSR');
-			$csr=$this->generateCSR($pem,$domains);
-		}elseif(openssl_csr_get_subject($pem)){ // CSR detected
-			$this->log('Using provided CSR');
-			if (0===strpos($pem,'file://')) {
-				$csr=file_get_contents(substr($pem,7));
-				if (false===$csr) {
-					throw new Exception('Failed to read CSR from '.$pem.' ('.$this->get_openssl_error().')');
-				}
-			}else{
-				$csr=$pem;
-			}
-		}else{
-			throw new Exception('Could not load Private Key or CSR ('.$this->get_openssl_error().'): '.$pem);
-		}
-
+		$deactivated=false;
+		
 		$this->getAccountID(); // get account info upfront to avoid mixed up logging order
 
 		// === Order ===
@@ -142,7 +124,7 @@ class ACMECert extends ACMEv2 { // ACMECert - PHP client library for Let's Encry
 		$this->log('Order created: '.$order_location);
 
 		// === Authorization ===
-		if ($order['status']==='ready') {
+		if ($order['status']==='ready' && !$force_validation) {
 			$this->log('All authorizations already valid, skipping validation altogether');
 		}else{
 			$groups=array();
@@ -161,7 +143,13 @@ class ACMECert extends ACMEv2 { // ACMECert - PHP client library for Let's Encry
 				).$authorization['identifier']['value'];
 
 				if ($authorization['status']==='valid') {
-					$this->log('Authorization of '.$domain.' already valid, skipping validation');
+					if ($force_validation) {
+						$this->log('Authorization of '.$domain.' already valid, deactivating authorization');
+						$deactivated=true;
+						$this->deactivate($auth_url);
+					}else{
+						$this->log('Authorization of '.$domain.' already valid, skipping validation');
+					}
 					continue;
 				}
 
@@ -172,6 +160,11 @@ class ACMECert extends ACMEv2 { // ACMECert - PHP client library for Let's Encry
 					'|'.
 					ltrim($domain,'*.')
 				][$domain]=array($auth_url,$authorization);
+			}
+			
+			if ($force_validation && $deactivated){
+				$this->log('Restarting Order after deactivating already valid authorizations');
+				return $this->getCertificateChain($pem,$domain_config,$callback);
 			}
 
 			// make sure dns-01 comes last to avoid DNS problems for other challenges
@@ -229,6 +222,25 @@ class ACMECert extends ACMEv2 { // ACMECert - PHP client library for Let's Encry
 					}
 				}
 			}
+		}
+		
+		// autodetect if Private Key or CSR is used
+		if ($key=openssl_pkey_get_private($pem)){ // Private Key detected
+			openssl_free_key($key);
+			$this->log('Generating CSR');
+			$csr=$this->generateCSR($pem,$domains);
+		}elseif(openssl_csr_get_subject($pem)){ // CSR detected
+			$this->log('Using provided CSR');
+			if (0===strpos($pem,'file://')) {
+				$csr=file_get_contents(substr($pem,7));
+				if (false===$csr) {
+					throw new Exception('Failed to read CSR from '.$pem.' ('.$this->get_openssl_error().')');
+				}
+			}else{
+				$csr=$pem;
+			}
+		}else{
+			throw new Exception('Could not load Private Key or CSR ('.$this->get_openssl_error().'): '.$pem);
 		}
 
 		$this->log('Finalizing Order');
@@ -650,7 +662,7 @@ class ACMEv2 { // Communication with Let's Encrypt via ACME v2 protocol
 			}
 		}
 		$method=$data===false?'HEAD':($data===null?'GET':'POST');
-		$user_agent='ACMECert v2.7 (+https://github.com/skoerfgen/ACMECert)';
+		$user_agent='ACMECert v2.8 (+https://github.com/skoerfgen/ACMECert)';
 		$header=($data===null||$data===false)?array():array('Content-Type: application/jose+json');
 		if ($this->ch) {
 			$headers=array();

--- a/README.md
+++ b/README.md
@@ -527,7 +527,9 @@ public string ACMECert::getCertificateChain ( mixed $pem, array $domain_config, 
 
 > **`force_validation`**
 >
-> If `TRUE` it is ensured that the callback function is called for each domain and does not get skipped due to eventually already valid authorizations.
+> If `TRUE` it is ensured that the callback function is called for each domain and does not get skipped due to possibly already valid authorizations. This is achived by deactivating already valid authorizations before getting new ones.
+> 
+> Only use for testing not in production!
 
 ###### Return Values
 > Returns a PEM encoded certificate chain.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ACMECert
 
 PHP client library for [Let's Encrypt](https://letsencrypt.org/) ([ACME v2 - RFC 8555](https://tools.ietf.org/html/rfc8555))  
-Version: 2.7
+Version: 2.8
 
 ## Description
 
@@ -455,7 +455,7 @@ Get certificate-chain (certificate + the intermediate certificate).
 
 *This is what Apache >= 2.4.8 needs for [`SSLCertificateFile`](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcertificatefile), and what Nginx needs for [`ssl_certificate`](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_certificate).*
 ```php
-public string ACMECert::getCertificateChain ( mixed $pem, array $domain_config, callable $callback )
+public string ACMECert::getCertificateChain ( mixed $pem, array $domain_config, callable $callback, bool $force_validation = FALSE )
 ```
 ###### Parameters
 > **`pem`**
@@ -524,6 +524,10 @@ public string ACMECert::getCertificateChain ( mixed $pem, array $domain_config, 
 >> http-01 | path + filename | file contents
 >> dns-01 | TXT Resource Record Name | TXT Resource Record Value
 >> tls-alpn-01 | unused | token used in the acmeIdentifier extension of the verification certificate; use [generateALPNCertificate](#acmecertgeneratealpncertificate) to generate the verification certificate from that token. (see the [tls-alpn-01 example](#get-certificate-using-all-http-01dns-01-and-tls-alpn-01-challenge-types-together))
+
+> **`force_validation`**
+>
+> If `TRUE` it is ensured that the callback function is called for each domain and does not get skipped due to eventually already valid authorizations.
 
 ###### Return Values
 > Returns a PEM encoded certificate chain.

--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ public string ACMECert::getCertificateChain ( mixed $pem, array $domain_config, 
 
 > **`force_validation`**
 >
-> If `TRUE` it is ensured that the callback function is called for each domain and does not get skipped due to possibly already valid authorizations. This is achived by deactivating already valid authorizations before getting new ones.
+> If `TRUE` it is ensured that the callback function is called for each domain and does not get skipped due to possibly already valid authorizations. This is achieved by deactivating already valid authorizations before getting new ones.
 > 
 > Only use for testing not in production!
 

--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ public string ACMECert::getCertificateChain ( mixed $pem, array $domain_config, 
 
 > **`authz_reuse`** (default: `TRUE`)
 >
-> If `FALSE` the callback function is always called for each domain and does not get skipped due to possibly already valid authorizations (authz) that get reused. This is achieved by deactivating already valid authorizations before getting new ones.
+> If `FALSE` the callback function is always called for each domain and does not get skipped due to possibly already valid authorizations (authz) that are reused. This is achieved by deactivating already valid authorizations before getting new ones.
 > 
 > > Hint: Under normal circumstances this is only needed when testing the callback function, not in production!
 

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ Get certificate-chain (certificate + the intermediate certificate).
 
 *This is what Apache >= 2.4.8 needs for [`SSLCertificateFile`](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcertificatefile), and what Nginx needs for [`ssl_certificate`](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_certificate).*
 ```php
-public string ACMECert::getCertificateChain ( mixed $pem, array $domain_config, callable $callback, bool $force_validation = FALSE )
+public string ACMECert::getCertificateChain ( mixed $pem, array $domain_config, callable $callback, bool $authz_reuse = TRUE )
 ```
 ###### Parameters
 > **`pem`**
@@ -525,11 +525,11 @@ public string ACMECert::getCertificateChain ( mixed $pem, array $domain_config, 
 >> dns-01 | TXT Resource Record Name | TXT Resource Record Value
 >> tls-alpn-01 | unused | token used in the acmeIdentifier extension of the verification certificate; use [generateALPNCertificate](#acmecertgeneratealpncertificate) to generate the verification certificate from that token. (see the [tls-alpn-01 example](#get-certificate-using-all-http-01dns-01-and-tls-alpn-01-challenge-types-together))
 
-> **`force_validation`**
+> **`authz_reuse`** (default: `TRUE`)
 >
-> If `TRUE` it is ensured that the callback function is called for each domain and does not get skipped due to possibly already valid authorizations. This is achieved by deactivating already valid authorizations before getting new ones.
+> If `FALSE` the callback function is always called for each domain and does not get skipped due to possibly already valid authorizations (authz) that get reused. This is achieved by deactivating already valid authorizations before getting new ones.
 > 
-> Only use for testing not in production!
+> > Hint: Under normal circumstances this is only needed when testing the callback function, not in production!
 
 ###### Return Values
 > Returns a PEM encoded certificate chain.


### PR DESCRIPTION
If `FALSE` the callback function is always called for each domain and does not get skipped due to possibly already valid authorizations (authz) that get reused. This is achieved by deactivating already valid authorizations before getting new ones.