### PR TITLE
Added support for DNS Names (domain names) longer than 64 chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ACMECert
 
 PHP client library for [Let's Encrypt](https://letsencrypt.org/) and other [ACME v2 - RFC 8555](https://tools.ietf.org/html/rfc8555) compatible Certificate Authorities.  
-Version: 3.3.0
+Version: 3.3.1
 
 ## Description
 
@@ -613,7 +613,7 @@ public string ACMECert::getCertificateChain ( mixed $pem, array $domain_config, 
 >
 > An Array defining the domains and the corresponding challenge types to get a certificate for.
 >
-> The first one is used as `Common Name` for the certificate.
+> The first domain name in the array is used as `Common Name` for the certificate if does not exceed 64 characters, otherwise the `Common Name` field will be empty.
 >
 > Here is an example structure:
 > ```php

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ public string ACMECert::getCertificateChain ( mixed $pem, array $domain_config, 
 >
 > An Array defining the domains and the corresponding challenge types to get a certificate for.
 >
-> The first domain name in the array is used as `Common Name` for the certificate if does not exceed 64 characters, otherwise the `Common Name` field will be empty.
+> The first domain name in the array is used as `Common Name` for the certificate if it does not exceed 64 characters, otherwise the `Common Name` field will be empty.
 >
 > Here is an example structure:
 > ```php

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "skoerfgen/acmecert",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"description": "PHP client library for Let's Encrypt and other ACME v2 - RFC 8555 compatible Certificate Authorities",
 	"license": "MIT",
 	"authors": [

--- a/src/ACMECert.php
+++ b/src/ACMECert.php
@@ -333,7 +333,11 @@ class ACMECert extends ACMEv2 {
 		}
 
 		$fn=$this->tmp_ssl_cnf($domains);
-		$dn=array('commonName'=>reset($domains));
+		$cn=reset($domains);
+		$dn=array();
+		if (strlen($cn)<=64){
+			$dn['commonName']=$cn;
+		}
 		$csr=openssl_csr_new($dn,$domain_key,array(
 			'config'=>$fn,
 			'req_extensions'=>'SAN',

--- a/src/ACMEv2.php
+++ b/src/ACMEv2.php
@@ -309,7 +309,7 @@ class ACMEv2 { // Communication with Let's Encrypt via ACME v2 protocol
 		}
 
 		$method=$data===false?'HEAD':($data===null?'GET':'POST');
-		$user_agent='ACMECert v3.3.0 (+https://github.com/skoerfgen/ACMECert)';
+		$user_agent='ACMECert v3.3.1 (+https://github.com/skoerfgen/ACMECert)';
 		$header=($data===null||$data===false)?array():array('Content-Type: application/jose+json');
 		if ($this->ch) {
 			$headers=array();


### PR DESCRIPTION
https://community.letsencrypt.org/t/simplifying-issuance-for-very-long-domain-names/207924