### PR TITLE
bugfix: ARI: openssl 'authorityKeyIdentifier'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ACMECert
 
 PHP client library for [Let's Encrypt](https://letsencrypt.org/) and other [ACME v2 - RFC 8555](https://tools.ietf.org/html/rfc8555) compatible Certificate Authorities.  
-Version: 3.4.0
+Version: 3.4.1
 
 ## Description
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "skoerfgen/acmecert",
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"description": "PHP client library for Let's Encrypt and other ACME v2 - RFC 8555 compatible Certificate Authorities",
 	"license": "MIT",
 	"authors": [

--- a/src/ACMECert.php
+++ b/src/ACMECert.php
@@ -467,10 +467,11 @@ class ACMECert extends ACMEv2 {
 		return $ret['body'];
 	}
 
-	function getARICertID($pem){
+	private function getARICertID($pem){
 		if (version_compare(PHP_VERSION,'7.1.2','<')){
 			throw new Exception('PHP Version >= 7.1.2 required for ARI'); // serialNumberHex - https://github.com/php/php-src/pull/1755
 		}
+
 		$ret=$this->parseCertificate($pem);
 
 		if (!isset($ret['extensions']['authorityKeyIdentifier'])) {
@@ -479,7 +480,6 @@ class ACMECert extends ACMEv2 {
 
 		$aki=trim($ret['extensions']['authorityKeyIdentifier']);
 		if (stripos($aki,'keyid')===0) $aki=substr($aki,5);
-
 		$aki=hex2bin(str_replace(':','',$aki));
 		if (!$aki) throw new Exception('Failed to parse authorityKeyIdentifier');
 
@@ -487,8 +487,8 @@ class ACMECert extends ACMEv2 {
 			throw new Exception('serialNumberHex missing');
 		}
 		$ser=hex2bin(trim($ret['serialNumberHex']));
-		if (ord($ser[0]) & 0x80) $ser="\x00".$ser;
 		if (!$ser) throw new Exception('Failed to parse serialNumberHex');
+		if (ord($ser[0]) & 0x80) $ser="\x00".$ser;
 
 		return $this->base64url($aki).'.'.$this->base64url($ser);
 	}

--- a/src/ACMECert.php
+++ b/src/ACMECert.php
@@ -467,7 +467,7 @@ class ACMECert extends ACMEv2 {
 		return $ret['body'];
 	}
 
-	private function getARICertID($pem){
+	function getARICertID($pem){
 		if (version_compare(PHP_VERSION,'7.1.2','<')){
 			throw new Exception('PHP Version >= 7.1.2 required for ARI'); // serialNumberHex - https://github.com/php/php-src/pull/1755
 		}
@@ -476,13 +476,18 @@ class ACMECert extends ACMEv2 {
 		if (!isset($ret['extensions']['authorityKeyIdentifier'])) {
 			throw new Exception('authorityKeyIdentifier missing');
 		}
-		$aki=hex2bin(str_replace(':','',substr(trim($ret['extensions']['authorityKeyIdentifier']),6)));
+
+		$aki=trim($ret['extensions']['authorityKeyIdentifier']);
+		if (stripos($aki,'keyid')===0) $aki=substr($aki,5);
+
+		$aki=hex2bin(str_replace(':','',$aki));
 		if (!$aki) throw new Exception('Failed to parse authorityKeyIdentifier');
 
 		if (!isset($ret['serialNumberHex'])) {
 			throw new Exception('serialNumberHex missing');
 		}
 		$ser=hex2bin(trim($ret['serialNumberHex']));
+		if (ord($ser[0]) & 0x80) $ser="\x00".$ser;
 		if (!$ser) throw new Exception('Failed to parse serialNumberHex');
 
 		return $this->base64url($aki).'.'.$this->base64url($ser);

--- a/src/ACMEv2.php
+++ b/src/ACMEv2.php
@@ -309,7 +309,7 @@ class ACMEv2 { // Communication with Let's Encrypt via ACME v2 protocol
 		}
 
 		$method=$data===false?'HEAD':($data===null?'GET':'POST');
-		$user_agent='ACMECert v3.4.0 (+https://github.com/skoerfgen/ACMECert)';
+		$user_agent='ACMECert v3.4.1 (+https://github.com/skoerfgen/ACMECert)';
 		$header=($data===null||$data===false)?array():array('Content-Type: application/jose+json');
 		if ($this->ch) {
 			$headers=array();


### PR DESCRIPTION
"keyid" prefix not present anymore in newer openssl versions