### PR TITLE
bugfix: getSAN: also return 'IP Address' fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ACMECert v3.7.0
+# ACMECert v3.7.1
 
 PHP client library for [Let's Encrypt](https://letsencrypt.org/) and other [ACME v2 - RFC 8555](https://tools.ietf.org/html/rfc8555) compatible Certificate Authorities.  
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "skoerfgen/acmecert",
-	"version": "3.7.0",
+	"version": "3.7.1",
 	"description": "PHP client library for Let's Encrypt and other ACME v2 - RFC 8555 compatible Certificate Authorities",
 	"license": "MIT",
 	"authors": [

--- a/src/ACMECert.php
+++ b/src/ACMECert.php
@@ -404,8 +404,8 @@ class ACMECert extends ACMEv2 {
 		}
 		$out=array();
 		foreach(explode(',',$ret['extensions']['subjectAltName']) as $line){
-			list($type,$name)=array_map('trim',explode(':',$line));
-			if ($type==='DNS'){
+			list($type,$name)=array_map('trim',explode(':',$line,2));
+			if ($type==='DNS' || $type==='IP Address'){
 				$out[]=$name;
 			}
 		}

--- a/src/ACMEv2.php
+++ b/src/ACMEv2.php
@@ -308,7 +308,7 @@ class ACMEv2 { // Communication with Let's Encrypt via ACME v2 protocol
 		}
 
 		$method=$data===false?'HEAD':($data===null?'GET':'POST');
-		$user_agent='ACMECert v3.7.0 (+https://github.com/skoerfgen/ACMECert)';
+		$user_agent='ACMECert v3.7.1 (+https://github.com/skoerfgen/ACMECert)';
 		$header=($data===null||$data===false)?array():array('Content-Type: application/jose+json');
 		if ($this->ch) {
 			$headers=array();


### PR DESCRIPTION
```php
Array
(
    [0] => 2602.ff3a.0001.abad.0c0f.0fee.abad.cafe
    [1] => 2602.ff3a.1.abad.c0f.fee.abad.cafe
    [2] => abad.cafe
    [3] => www.abad.cafe
    [4] => 2602:FF3A:1:ABAD:C0F:FEE:ABAD:CAFE
)
```
https://community.letsencrypt.org/t/getting-ready-to-issue-ip-address-certificates/238777